### PR TITLE
Covert mouse to pointer on menu entry hover

### DIFF
--- a/douki.user.js
+++ b/douki.user.js
@@ -350,7 +350,7 @@ class DomMethods {
         const selector = '.header-menu-dropdown > ul > li:last-child';
         const dropdown = document.querySelector(selector);
         if (dropdown) {
-            const html = `<li><a aria-role="button" id="${const_1.DROPDOWN_ITEM_ID}">Import from Anilist</a></li>`;
+            const html = `<li><a aria-role="button" style="cursor: pointer" id="${const_1.DROPDOWN_ITEM_ID}">Import from Anilist</a></li>`;
             dropdown.insertAdjacentHTML('afterend', html);
             const link = document.querySelector(Util_1.id(const_1.DROPDOWN_ITEM_ID));
             link && link.addEventListener('click', function (e) {

--- a/src/Dom.ts
+++ b/src/Dom.ts
@@ -87,7 +87,7 @@ export class DomMethods implements IDomMethods {
         const selector = '.header-menu-dropdown > ul > li:last-child';
         const dropdown = document.querySelector(selector);
         if (dropdown) {
-            const html = `<li><a aria-role="button" id="${DROPDOWN_ITEM_ID}">Import from Anilist</a></li>`;
+            const html = `<li><a aria-role="button" style="cursor: pointer" id="${DROPDOWN_ITEM_ID}">Import from Anilist</a></li>`;
             dropdown.insertAdjacentHTML('afterend', html);
             const link = document.querySelector(id(DROPDOWN_ITEM_ID));
             link && link.addEventListener('click', function (e) {


### PR DESCRIPTION
The custom menu entry misses the href attribute which is responsible
for converting the mouse to a pointer on hover.
In order to make it more consistent we can add the style manually.